### PR TITLE
build(pre-commit): fix `clippy` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,4 @@ repos:
         language: system
         entry: just clippy
         types: [rust]
+        pass_filenames: false


### PR DESCRIPTION
Don't pass file names

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/wizard-28/wealthy/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/wizard-28/wealthy/blob/master/CHANGELOG.md
-->
