### PR TITLE
build(justfile): remove `distclean`

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,12 +21,9 @@ setup-dev:
 check: spellcheck fmt clippy test
     @echo Checks were successful!
 
+# Remove generated artifacts
 clean:
     @cargo clean
-    @echo Done!
-
-distclean:
-    @rm --recursive --force .cargo target
     @echo Done!
 
 # Build the project


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Removes `distclean` recipe, as it's redundant.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/wizard-28/wealthy/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/wizard-28/wealthy/blob/master/CHANGELOG.md
-->
