### PR TITLE
Utilize `.codespellignore` file

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,8 @@
+ba
+fo
+hel
+revered
+womens
+
+crate
+mut

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: codespell-project/actions-codespell@master
         with:
           builtin: clear,rare,informal,code
-          ignore_words_list: crate,womens
+          ignore_words_file: .codespellignore
 
   clippy:
     name: Clippy

--- a/justfile
+++ b/justfile
@@ -47,5 +47,5 @@ fmt +ARGS="":
 
 # Spellcheck the codebase
 spellcheck +ARGS="--skip target*":
-    @codespell --write-changes --builtin clear,rare,informal,code --ignore-words-list crate,womens {{ARGS}}
+    @codespell --write-changes --builtin clear,rare,informal,code -I .codespellignore {{ARGS}}
     @echo Spellings look good!


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Make a single `.codespellignore` file, and utilize it both in Just, and the CI.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/wizard-28/wealthy/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/wizard-28/wealthy/blob/master/CHANGELOG.md
-->
